### PR TITLE
Fix getting unverified content from query params

### DIFF
--- a/tests/test_views.py
+++ b/tests/test_views.py
@@ -64,6 +64,39 @@ def test_get_with_valid_callback(client):
     ).exists()
 
 
+@pytest.mark.django_db
+def test_get_with_valid_callback_with_unordered_query_parameters(client):
+    response = client.get(
+        path="/admob-ssv/",
+        data={
+            "ad_network": 5450213213286189855,
+            "ad_unit": 1234567890,
+            "custom_data": "customdata42",
+            "reward_amount": 1,
+            "reward_item": "Reward",
+            "signature": "MEQCIAhKY5P-aBmjU0iqxtjq2JPzeNKnQ92ZbSPC33Sp4ByeAiBArqhg9_uafB1LCBYVIXWNOW8vVVlocLc81ptROfE44Q",
+            "timestamp": 1683852940453,
+            "transaction_id": 123456789,
+            "key_id": 3335741209,
+            "user_id": "userid42",
+        },
+    )
+
+    assert response.status_code == 200
+    assert Verification.objects.filter(
+        ad_network=5450213213286189855,
+        ad_unit=1234567890,
+        custom_data="customdata42",
+        key_id=3335741209,
+        reward_amount=1,
+        reward_item="Reward",
+        signature="MEQCIAhKY5P-aBmjU0iqxtjq2JPzeNKnQ92ZbSPC33Sp4ByeAiBArqhg9_uafB1LCBYVIXWNOW8vVVlocLc81ptROfE44Q",
+        timestamp=1683852940453,
+        transaction_id="123456789",
+        user_id="userid42",
+    ).exists()
+
+
 def test_get_with_missing_signature(client):
     response = client.get(
         path="/admob-ssv/",


### PR DESCRIPTION
This pull request addresses an edge case where query parameters can be unordered when receiving AdMob callback on the Django server. The proposed changes ensure that the code accommodates the scenario of unordered query parameters, providing a more robust solution for handling AdMob callbacks in Django.





